### PR TITLE
Merge update to 0.4.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: naijR
 Type: Package
 Title: Operations to Ease Data Analyses Specific to Nigeria
-Version: 0.4.3
-Date: 2022-07-21
+Version: 0.4.3.9000
+Date: 2022-08-12
 Depends: 
     R (>= 3.6),
     grDevices,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: naijR
 Type: Package
 Title: Operations to Ease Data Analyses Specific to Nigeria
-Version: 0.4.3.9000
-Date: 2022-08-12
+Version: 0.4.4
+Date: 2022-08-30
 Depends: 
     R (>= 3.6),
     grDevices,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# naijR 0.4.4
+## Bug fix:
+
+* `fix_mobile` fails unexpectedly when only `NA` is supplied as argument. This causes practical problems when, for example, it encounters a column with only missing values.
+
+# naijR 0.4.3
+* Addressed a build problem related to CRAN submission.
+
 # naijR 0.4.2
 * Improved type checking for mapping functionality and better fidelity.
 

--- a/R/mobile.R
+++ b/R/mobile.R
@@ -14,11 +14,12 @@
 #'
 #' @export
 fix_mobile <- function(x) {
-  if (!is.character(x)) {
-    if (!is.numeric(x))
-      stop(sprintf("Objects of type %s are not supported", sQuote(typeof(x))))
+  if (!is.null(x) && all(is.na(x)) || is.numeric(x))
     x <- as.character(x)
-  }
+  
+  if (!is.character(x)) 
+    stop(sprintf("Objects of type %s are not supported", sQuote(typeof(x))))
+  
   # Remove entries that are beyond redemption i.e. too long or too short
   # then add a leading '0' if there are 10 digits
   # and then remove those that still don't look like local mobile numbers (NG)

--- a/tests/testthat/test-mobile.R
+++ b/tests/testthat/test-mobile.R
@@ -32,7 +32,9 @@ test_that("Input corner cases are checked", {
   err1 <- "Objects of type .+ are not supported"
   
   expect_error(fix_mobile(NULL), err1)
-  expect_error(fix_mobile(NA), err1)
+  expect_type(fix_mobile(NA), "character")
+  expect_identical(fix_mobile(NA), NA_character_)
+  expect_identical(fix_mobile(c("8034510441", NA))[2], NA_character_)
   expect_error(fix_mobile(data.frame(x = c(09012343829, 08132348321))), err1)
   expect_error(fix_mobile(), "argument \"x\" is missing, with no default")
 })


### PR DESCRIPTION
# naijR 0.4.4
## Bug fix:

* `fix_mobile` fails unexpectedly when only `NA` is supplied as argument. This causes practical problems when, for example, it encounters a column with only missing values.